### PR TITLE
Preserve markup on edit

### DIFF
--- a/handlers/post.js
+++ b/handlers/post.js
@@ -60,7 +60,8 @@ composer.on('channel_post', async (ctx, next) => {
 
   const updateResult = await keyboardUpdate(post.channel.channelId, post.channelMessageId, {
     type: messageType,
-    text: newText
+    text: newText,
+    entities: ctx.message.entities
   })
 
   if (updateResult.error && updateResult.error.code === 400 && !ctx.channelPost.forward_from_message_id) {

--- a/helpers/update-keyboard.js
+++ b/helpers/update-keyboard.js
@@ -55,7 +55,7 @@ const keyboardUpdate = async (channelId, channelMessageId, message) => {
     reply_markup: JSON.stringify({ inline_keyboard: [votesKeyboardArray].concat(post.keyboard) })
   }
 
-  if (message && message.type) {
+  if (message) {
     if (message.type === 'text') {
       methodUpdate = 'editMessageText'
       optsUpdate.text = message.text
@@ -63,6 +63,9 @@ const keyboardUpdate = async (channelId, channelMessageId, message) => {
     if (message.type === 'media') {
       methodUpdate = 'editMessageCaption'
       optsUpdate.caption = message.text
+    }
+    if (message.entities) {
+      optsUpdate.entities = message.entities
     }
   }
 


### PR DESCRIPTION
Right now when the bot adds reactions to the post, it loses the message's markup.