### PR TITLE
Correctly provide entities for posts with media type

### DIFF
--- a/handlers/post.js
+++ b/handlers/post.js
@@ -61,7 +61,7 @@ composer.on('channel_post', async (ctx, next) => {
   const updateResult = await keyboardUpdate(post.channel.channelId, post.channelMessageId, {
     type: messageType,
     text: newText,
-    entities: ctx.channelPost.entities
+    entities: ctx.channelPost.entities || ctx.channelPost.caption_entities
   })
 
   if (updateResult.error && updateResult.error.code === 400 && !ctx.channelPost.forward_from_message_id) {

--- a/helpers/update-keyboard.js
+++ b/helpers/update-keyboard.js
@@ -59,13 +59,12 @@ const keyboardUpdate = async (channelId, channelMessageId, message) => {
     if (message.type === 'text') {
       methodUpdate = 'editMessageText'
       optsUpdate.text = message.text
+      optsUpdate.entities = message.entities
     }
     if (message.type === 'media') {
       methodUpdate = 'editMessageCaption'
       optsUpdate.caption = message.text
-    }
-    if (message.entities) {
-      optsUpdate.entities = message.entities
+      optsUpdate.caption_entities = message.entities
     }
   }
 


### PR DESCRIPTION
The title :) I checked the changes on my channel: now the markup is not lost.