### PR TITLE
Upgrade emoji-db

### DIFF
--- a/handlers/channels.js
+++ b/handlers/channels.js
@@ -2,15 +2,13 @@ const Composer = require('telegraf/composer')
 const Scene = require('telegraf/scenes/base')
 const Markup = require('telegraf/markup')
 const { match } = require('telegraf-i18n')
-const EmojiDbLib = require('emoji-db')
 const {
   scenes
 } = require('../middlewares')
 const {
-  getChannel
+  getChannel,
+  findEmojis
 } = require('../helpers')
-
-const emojiDb = new EmojiDbLib({ useDefaultDb: true })
 
 const composer = new Composer()
 
@@ -70,9 +68,8 @@ setChannelEmoji.enter(async ctx => {
 setChannelEmoji.on('text', async ctx => {
   const channel = await ctx.db.Channel.findById(ctx.scene.state.channelId)
 
-  const emojis = emojiDb.searchFromText({ input: ctx.message.text, fixCodePoints: true })
-  const emojisArray = emojis.map(data => data.emoji)
-  channel.settings.emojis = emojisArray.join('')
+  const emojis = findEmojis(ctx.message.text)
+  channel.settings.emojis = emojis.join('')
   if (channel.settings.emojis.length <= 0) channel.settings.emojis = new ctx.db.Channel().settings.emojis
   await channel.save()
 

--- a/handlers/post.js
+++ b/handlers/post.js
@@ -1,10 +1,8 @@
 const Composer = require('telegraf/composer')
-const EmojiDbLib = require('emoji-db')
 const {
-  keyboardUpdate
+  keyboardUpdate,
+  findEmojis
 } = require('../helpers')
-
-const emojiDb = new EmojiDbLib({ useDefaultDb: true })
 
 const composer = new Composer()
 
@@ -25,7 +23,7 @@ composer.on('channel_post', async (ctx, next) => {
     const lastLine = textLines.pop()
 
     if (lastLine[0] === '!') {
-      const emojisFromLine = emojiDb.searchFromText({ input: lastLine, fixCodePoints: true })
+      const emojisFromLine = findEmojis(lastLine)
       if (emojisFromLine.length > 0) emojis = emojisFromLine
 
       newText = textLines.join('\n')
@@ -36,11 +34,11 @@ composer.on('channel_post', async (ctx, next) => {
   }
 
   if (!emojis && ctx.session.channelInfo.settings.type === 'request') return next()
-  if (!emojis) emojis = emojiDb.searchFromText({ input: ctx.session.channelInfo.settings.emojis, fixCodePoints: true })
+  if (!emojis) emojis = findEmojis(ctx.session.channelInfo.settings.emojis)
 
-  emojis.forEach(data => {
+  emojis.forEach(emoji => {
     votesRateArray.push({
-      name: data.emoji,
+      name: emoji,
       vote: []
     })
   })

--- a/helpers/find-emojis.js
+++ b/helpers/find-emojis.js
@@ -1,0 +1,13 @@
+const createEmojiRegex = require('emoji-regex')
+
+const emojiRegex = createEmojiRegex()
+
+module.exports = (str) => {
+  const emojis = str.matchAll(emojiRegex)
+  const result = []
+  for (const emoji of emojis) {
+    result.push(emoji[0])
+  }
+
+  return result
+}

--- a/helpers/index.js
+++ b/helpers/index.js
@@ -2,5 +2,6 @@ module.exports = {
   getUser: require('./user-get'),
   getChannel: require('./channel-get'),
   getGroup: require('./group-get'),
-  keyboardUpdate: require('./update-keyboard')
+  keyboardUpdate: require('./update-keyboard'),
+  findEmojis: require('./find-emojis')
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@pm2/io": "^4.3.5",
         "dotenv": "^8.6.0",
-        "emoji-db": "^14.0.1",
+        "emoji-regex": "^10.2.1",
         "mongoose": "^5.13.2",
         "telegraf": "^3.39.0",
         "telegraf-i18n": "^6.6.0",
@@ -655,16 +655,10 @@
         "shimmer": "^1.2.0"
       }
     },
-    "node_modules/emoji-db": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-14.0.1.tgz",
-      "integrity": "sha512-MFiCUr4DsehfCRPAS845AJR4RsekQkh4bUpfag7de3H7FlDHAEbL8Oq03bPzhl4W6rJgrGFhRkcll101ZpQjjg=="
-    },
     "node_modules/emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "node_modules/error-ex": {
       "version": "1.3.2",
@@ -3022,6 +3016,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/string-width/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
     "node_modules/string-width/node_modules/strip-ansi": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -3938,16 +3938,10 @@
         "shimmer": "^1.2.0"
       }
     },
-    "emoji-db": {
-      "version": "14.0.1",
-      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-14.0.1.tgz",
-      "integrity": "sha512-MFiCUr4DsehfCRPAS845AJR4RsekQkh4bUpfag7de3H7FlDHAEbL8Oq03bPzhl4W6rJgrGFhRkcll101ZpQjjg=="
-    },
     "emoji-regex": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
-      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
-      "dev": true
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.2.1.tgz",
+      "integrity": "sha512-97g6QgOk8zlDRdgq1WxwgTMgEWGVAQvB5Fdpgc1MkNy56la5SKP9GsMXKDOdqwn90/41a8yPwIGk1Y6WVbeMQA=="
     },
     "error-ex": {
       "version": "1.3.2",
@@ -5765,6 +5759,12 @@
         "strip-ansi": "^6.0.0"
       },
       "dependencies": {
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
         "strip-ansi": {
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "reacombot",
-  "version": "0.3.11",
+  "version": "0.3.12",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "reacombot",
-      "version": "0.3.11",
+      "version": "0.3.12",
       "license": "MIT",
       "dependencies": {
         "@pm2/io": "^4.3.5",
         "dotenv": "^8.6.0",
-        "emoji-db": "^1.14.0",
+        "emoji-db": "^14.0.1",
         "mongoose": "^5.13.2",
         "telegraf": "^3.39.0",
         "telegraf-i18n": "^6.6.0",
@@ -656,9 +656,9 @@
       }
     },
     "node_modules/emoji-db": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-1.14.0.tgz",
-      "integrity": "sha512-3RNr5R1nU7W5kvgx5S+JyZJrXN5nVDqCUhpzH5YuaJhyuYSx1FVpjgvQOqsT1Y1Spu6uqYb+HFksFkwmBhQZ2A=="
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-14.0.1.tgz",
+      "integrity": "sha512-MFiCUr4DsehfCRPAS845AJR4RsekQkh4bUpfag7de3H7FlDHAEbL8Oq03bPzhl4W6rJgrGFhRkcll101ZpQjjg=="
     },
     "node_modules/emoji-regex": {
       "version": "8.0.0",
@@ -3939,9 +3939,9 @@
       }
     },
     "emoji-db": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-1.14.0.tgz",
-      "integrity": "sha512-3RNr5R1nU7W5kvgx5S+JyZJrXN5nVDqCUhpzH5YuaJhyuYSx1FVpjgvQOqsT1Y1Spu6uqYb+HFksFkwmBhQZ2A=="
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/emoji-db/-/emoji-db-14.0.1.tgz",
+      "integrity": "sha512-MFiCUr4DsehfCRPAS845AJR4RsekQkh4bUpfag7de3H7FlDHAEbL8Oq03bPzhl4W6rJgrGFhRkcll101ZpQjjg=="
     },
     "emoji-regex": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@pm2/io": "^4.3.5",
     "dotenv": "^8.6.0",
-    "emoji-db": "^14.0.1",
+    "emoji-regex": "^10.2.1",
     "mongoose": "^5.13.2",
     "telegraf": "^3.39.0",
     "telegraf-i18n": "^6.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "@pm2/io": "^4.3.5",
     "dotenv": "^8.6.0",
-    "emoji-db": "^1.14.0",
+    "emoji-db": "^14.0.1",
     "mongoose": "^5.13.2",
     "telegraf": "^3.39.0",
     "telegraf-i18n": "^6.6.0",


### PR DESCRIPTION
Upgrade `emoji-db` to be up-to-date with the current Telegram emoji level.

This fix will allow me to add reactions with 🫶🫰 emojis.

- [x] I have tested it:
![image](https://user-images.githubusercontent.com/4787256/226459314-aae3f90b-a5ba-4274-ab2c-a8153188e93b.png)
